### PR TITLE
fix(): Refine borrow/repay button border-radii

### DIFF
--- a/src/components/home/BorrowRepayButton.tsx
+++ b/src/components/home/BorrowRepayButton.tsx
@@ -30,7 +30,7 @@ const RadioCard: FC<UseRadioProps> = ({ children, ...props }) => {
             "linear-gradient(95.32deg, #2F55DE -18.91%, #EA5332 148.09%)",
           color: "white",
           boxShadow,
-          borderRadius: "10px",
+          borderRadius: "7px",
         }}
         px={8}
         py={3}
@@ -58,10 +58,10 @@ export const BorrowRepayButton: FC<UseRadioGroupProps> = ({ ...props }) => {
       <Stack
         direction="row"
         p="2px"
-        borderRadius="10px"
+        borderRadius="9px"
         background="linear-gradient(95.32deg, #2F55DE -18.91%, #EA5332 148.09%)"
       >
-        <HStack borderRadius="10px" bgColor="rgb(41,42,61)" spacing="0" p="2px">
+        <HStack borderRadius="8px" bgColor="rgb(41,42,61)" spacing="0" p="2px">
           {options.map((value) => {
             const radio = getRadioProps({ value });
             return (


### PR DESCRIPTION
The `BorrowRepayButton` component has some border-radius issues.

<img width="782" alt="before" src="https://user-images.githubusercontent.com/98366622/151065630-bda5103b-da81-4ad0-a9c6-24e7f9ac5c9d.png">

This tiny PR just aims at refining the corners by utilizing decreasing border-radii depending on the HTML hierarchy.

#### AFTER
<img width="782" alt="after" src="https://user-images.githubusercontent.com/98366622/151066028-ee18f07f-4517-4281-a7f9-a8289e1a4a3f.png">

