### PR TITLE
Improve SwapBox UI on mobile

### DIFF
--- a/src/components/home/SwapBox.tsx
+++ b/src/components/home/SwapBox.tsx
@@ -359,7 +359,7 @@ const Borrow = ({ ...props }) => {
       <VStack spacing={{ base: "4", md: "6" }} alignItems="center">
         <VStack width="100%" spacing={{ base: "2", md: "4" }} alignItems="left">
           <Text fontSize="sm">Deposit Collateral</Text>
-          <Flex alignItems="center">
+          <HStack>
             <TokenMenu onChangeCallback={onReset} />
             <TokenAmountInput
               size="lg"
@@ -369,7 +369,7 @@ const Borrow = ({ ...props }) => {
               onUserInput={(input) => setAmount(input)}
               showMaxButton
             />
-          </Flex>
+          </HStack>
           {Number(amount) > Number(formatEther(tokenBalance)) && (
             <Text fontSize={12} color="red.300">
               Insufficient funds

--- a/src/components/home/YourPositions.tsx
+++ b/src/components/home/YourPositions.tsx
@@ -95,7 +95,7 @@ export const YourPositions: FC<YourPositionProps> = ({
   const tokenInfos = [...TokenInfos.values()];
 
   return (
-    <BlurryBox {...props}>
+    <BlurryBox {...props} zIndex="-1">
       <Heading mb="8" size="lg">
         Your Positions
       </Heading>

--- a/src/components/input/TokenAmountInput.tsx
+++ b/src/components/input/TokenAmountInput.tsx
@@ -87,6 +87,7 @@ export const TokenAmountInput: React.FC<Props> = ({
           isInvalid={parseUnits(sanitize(value), tokenDecimals).gt(
             parseUnits(max, tokenDecimals)
           )}
+          {...(showMaxButton || inputRightElement ? { pr: "4rem" } : {})}
           {...rest}
         />
         {(showMaxButton || inputRightElement) && (

--- a/src/components/menu/TokenMenu.tsx
+++ b/src/components/menu/TokenMenu.tsx
@@ -61,14 +61,14 @@ export const TokenMenu: FC<TokenMenuProps> = ({ ...props }) => {
 
   return (
     <Menu {...props} autoSelect={false}>
-      <MenuButton>
-        <HStack width={{ base: "initial", md: "9rem" }}>
+      <MenuButton h={12}>
+        <HStack spacing={[0, 0, 2]} width={{ base: "initial", md: "9rem" }}>
           {!props.showAll && !TokenInfos.get(tokenId)?.collateral ? (
             <TokenMenuItemContent token={TokenInfos.get(TokenId.Core)} />
           ) : (
             <TokenMenuItemContent token={TokenInfos.get(tokenId)} />
           )}
-          <ChevronDownIcon />
+          <ChevronDownIcon boxSize={6} />
         </HStack>
       </MenuButton>
       <MenuList background="#303042" zIndex="999">


### PR DESCRIPTION
- [x] prevent the Repay menu list from being hidden behind the YourPositions component
- [x] prevent the input text from overlapping the Max button
- [x] increase the height of the menu button from 24px to 48px (Apple, in his Human Interface Guidelines, recommends at least 44px). 48px corresponds to the height of the input field. It doesn't have any visual impact, it only makes the clickable area a bit bigger
- [x] increase the size of the ChevronDown icon from 16px to 24px and improve its positioning

#### VISUALS

**Before**
<img width="376" alt="menulist-before" src="https://user-images.githubusercontent.com/98366622/151683626-fd018dd6-f648-49c3-96bc-2c1b76c3c9e5.png">

**After**
<img width="378" alt="menulist-after" src="https://user-images.githubusercontent.com/98366622/151683630-d7330ebe-7a6c-4e46-a83a-2543e6285a4a.png">


**Before**
<img width="176" alt="overlapping-input-text-before" src="https://user-images.githubusercontent.com/98366622/151683863-a8a8e302-ba0d-4dcc-b3e8-a30738e35521.png">

**After**
<img width="176" alt="overlapping-input-text-after" src="https://user-images.githubusercontent.com/98366622/151683866-53ed56bc-5ad4-4bd4-bae1-9b52cfe818a6.png">


**Before**
<img width="376" alt="Capture d’écran 2022-01-30 à 03 04 43" src="https://user-images.githubusercontent.com/98366622/151683895-7321e613-4cd5-4baa-bb9c-b97b5a5ee592.png">

**After**
<img width="365" alt="Capture d’écran 2022-01-30 à 03 04 23" src="https://user-images.githubusercontent.com/98366622/151683903-197ae72b-2ec7-4857-b6e9-31603ed9546f.png">
